### PR TITLE
Fix `divide_numbers` type error

### DIFF
--- a/buggy_code.py
+++ b/buggy_code.py
@@ -1,17 +1,25 @@
 # buggy_code.py
 
 def calculate_sum(a, b):
-    # 故意引入一个语法错误：缺少右括号
-    print("Calculating sum for", a, b
+    # Fixed syntax error: added missing closing parenthesis
+    print("Calculating sum for", a, b)
     return a + b
 
 def divide_numbers(x, y):
-    # 故意引入一个逻辑错误：除数为零的风险，或者类型错误
-    # if y == 0:
-    #     return "Error: Cannot divide by zero"
-
-    # 故意引入一个类型错误：尝试将字符串和数字相加
-    result = "The result is: " + y
+    # Check for type errors
+    try:
+        # Attempt to convert to float to handle numeric strings
+        x = float(x)
+        y = float(y)
+    except (TypeError, ValueError):
+        return "Error: Both arguments must be numeric"
+    
+    # Check for zero division
+    if y == 0:
+        return "Error: Cannot divide by zero"
+    
+    # Perform the division
+    result = x / y
     return result
 
 if __name__ == "__main__":
@@ -20,10 +28,14 @@ if __name__ == "__main__":
     print(f"Sum: {sum_result}")
 
     # 测试 divide_numbers
+    # Test normal division
+    div_result_normal = divide_numbers(10, 2)
+    print(f"Division 10/2: {div_result_normal}")
+    
+    # Test zero division
     div_result = divide_numbers(10, 0) # 故意制造除零错误
-    print(f"Division: {div_result}")
+    print(f"Division by zero: {div_result}")
 
+    # Test type error
     div_result_type_error = divide_numbers(10, "hello") # 故意制造类型错误
-    print(f"Division with type error: {div_result_type_error}")
-    print(f"Division with type error: {div_result_type_error}")
     print(f"Division with type error: {div_result_type_error}")


### PR DESCRIPTION
Refactor `divide_numbers` to correctly perform numerical division with robust error handling for zero-division and non-numeric inputs.

The original `divide_numbers` function was incorrectly concatenating a string with one of its inputs (`y`) instead of performing division, leading to `TypeError` and ignoring the division logic entirely. This PR corrects the function to perform proper numerical division, including checks for zero-division and graceful handling of non-numeric input types. A minor syntax error in `calculate_sum` was also fixed to allow the test file to run.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-48bcd9c4-1ad9-49c9-9dc1-d1703ba428e1) · [Cursor](https://cursor.com/background-agent?bcId=bc-48bcd9c4-1ad9-49c9-9dc1-d1703ba428e1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)